### PR TITLE
Fix for ocaml 4.09.1

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -15,7 +15,7 @@ type section = Code | Dlpt | Dlls | Prim | Data | Symb | Crcs | Dbug
 
 type t = (section * int * int) list
 
-let magic_str = "Caml1999X023"
+let magic_str = "Caml1999X026"
 
 let parse ic =
   let magic_size = String.length magic_str in

--- a/src/step1.ml
+++ b/src/step1.ml
@@ -91,7 +91,7 @@ let prepare_code old_code cleanables ignore_fulls =
                   f (succ indg) adds cleans
               | None -> f (succ indg) adds cleans
           else
-            (List.sort Pervasives.compare adds, cleans)
+            (List.sort Stdlib.compare adds, cleans)
   in
   let adds, cleans = f 0 [] [] in
   let old_code_size = Array.length old_code in


### PR DESCRIPTION
This pull request makes ocamlclean compilable and usable with ocaml 4.09.1 (latest stable)